### PR TITLE
Fix corrupted Parametric Stereo (PS) flag in downloaded .m3u8 videos

### DIFF
--- a/fastanime/Utility/downloader/downloader.py
+++ b/fastanime/Utility/downloader/downloader.py
@@ -43,6 +43,8 @@ class YtDLPDownloader:
         merge=False,
         clean=False,
         prompt=True,
+        force_ffmpeg=False,
+        hls_use_mpegts=False,
     ):
         """Helper function that downloads anime given url and path details
 
@@ -91,7 +93,23 @@ class YtDLPDownloader:
         vid_path = ""
         sub_path = ""
         for i, url in enumerate(urls):
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            options = ydl_opts
+            if i == 0:
+                if force_ffmpeg:
+                    options = options | {
+                        "external_downloader": {
+                            'default': 'ffmpeg'
+                        },
+                        "external_downloader_args": {
+                            "ffmpeg_i1": ["-v", "error", "-stats"],
+                        },
+                    }
+                if hls_use_mpegts:
+                    options = options | {
+                        "hls_use_mpegts": hls_use_mpegts,
+                    }
+
+            with yt_dlp.YoutubeDL(options) as ydl:
                 info = ydl.extract_info(url, download=True)
             if not info:
                 continue

--- a/fastanime/cli/commands/anilist/download.py
+++ b/fastanime/cli/commands/anilist/download.py
@@ -110,6 +110,16 @@ from .data import (
     default=True,
 )
 @click.option(
+    "--force-ffmpeg",
+    is_flag=True,
+    help="Force the use of FFmpeg for downloading (supports large variety of streams but slower)",
+)
+@click.option(
+    "--hls-use-mpegts",
+    is_flag=True,
+    help="Use mpegts for hls streams (useful for some streams: see Docs) (this option forces --force-ffmpeg to be True)",
+)
+@click.option(
     "--max-results", "-M", type=int, help="The maximum number of results to show"
 )
 @click.pass_obj
@@ -132,10 +142,14 @@ def download(
     clean,
     wait_time,
     prompt,
+    force_ffmpeg,
+    hls_use_mpegts,
     max_results,
 ):
     from ....anilist import AniList
     from rich import print
+
+    force_ffmpeg |= hls_use_mpegts
 
     success, anilist_search_results = AniList.search(
         query=title,
@@ -367,6 +381,8 @@ def download(
                         merge=merge,
                         clean=clean,
                         prompt=prompt,
+                        force_ffmpeg=force_ffmpeg,
+                        hls_use_mpegts=hls_use_mpegts,
                     )
                 except Exception as e:
                     print(e)

--- a/fastanime/cli/commands/download.py
+++ b/fastanime/cli/commands/download.py
@@ -114,6 +114,16 @@ if TYPE_CHECKING:
     help="Whether to prompt for anything instead just do the best thing",
     default=True,
 )
+@click.option(
+    "--force-ffmpeg",
+    is_flag=True,
+    help="Force the use of FFmpeg for downloading (supports large variety of streams but slower)",
+)
+@click.option(
+    "--hls-use-mpegts",
+    is_flag=True,
+    help="Use mpegts for hls streams (useful for some streams: see Docs) (this option forces --force-ffmpeg to be True)",
+)
 @click.pass_obj
 def download(
     config: "Config",
@@ -127,6 +137,8 @@ def download(
     clean,
     wait_time,
     prompt,
+    force_ffmpeg,
+    hls_use_mpegts,
 ):
     import time
 
@@ -145,6 +157,8 @@ def download(
         fuzzy_inquirer,
         move_preferred_subtitle_lang_to_top,
     )
+
+    force_ffmpeg |= hls_use_mpegts
 
     anime_provider = AnimeProvider(config.provider)
     anilist_anime_info = None
@@ -185,6 +199,8 @@ def download(
                 clean,
                 wait_time,
                 prompt,
+                force_ffmpeg,
+                hls_use_mpegts,
             )
             return
         search_results = search_results["results"]
@@ -236,6 +252,8 @@ def download(
                 clean,
                 wait_time,
                 prompt,
+                force_ffmpeg,
+                hls_use_mpegts,
             )
             return
 
@@ -369,6 +387,8 @@ def download(
                     merge=merge,
                     clean=clean,
                     prompt=prompt,
+                    force_ffmpeg=force_ffmpeg,
+                    hls_use_mpegts=hls_use_mpegts,
                 )
             except Exception as e:
                 print(e)


### PR DESCRIPTION
# What this PR does
- added --force-ffmpeg & --hls-use-mpegts options to properly handle some m3u8 streams 

# Explanation 
### Fix corrupted Parametric Stereo (PS) flag in downloaded videos
Corrupted PS flag was caused by `yt-dlp` copping audio stream directly from `aac (HE-AACv2)` stream
without converting it to stereo channels first which resulted in mono channel `aac (LC)`.

As pointed in #8: FFprobe (and FFmpeg) recognized `aac (HE-AACv2)` pattern in the downloaded videos
but because the PS flag wasn't being carried over from the original `.m3u8`, 
it noticed something was wrong hence, the error.

This is a big loss of data, since most players can read stereo data from `aac (HE-AACv2)`, 
but not from a loosely copied over `aac (LC)`, which only mono data can be retrieved.

The issue can now be solved by passing `--hls-use-mpegts` flag to Fastanime which will apply the fix.

# The Fixes
### Fix corrupted Parametric Stereo (PS) flag in downloaded videos
The fix is to tell `yt-dlp` to use FFmpeg instead of its build-in downloader which doesn't supports hls streams,
and force it use mpegts for the output container.