### PR TITLE
Creating an installation Script For Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 ![Windows](https://img.shields.io/badge/-Windows_x64-blue.svg?style=for-the-badge&logo=windows)
 ![Linux/BSD](https://img.shields.io/badge/-Linux/BSD-red.svg?style=for-the-badge&logo=linux)
-![Arch Linux](https://img.shields.io/badge/-Arch_Linux-black.svg?style=for-the-badge&logo=archlinux)
+<a href="#installation-on-arch-linux" target="_blank"> <img src="https://img.shields.io/badge/-Arch_Linux-black.svg?style=for-the-badge&logo=archlinux" alt="Arch Linux"> </a>
 ![MacOS](https://img.shields.io/badge/-MacOS-lightblue.svg?style=for-the-badge&logo=apple)
 ![Android](https://img.shields.io/badge/-Android-green.svg?style=for-the-badge&logo=android)
 
@@ -56,12 +56,58 @@ The app can run wherever python can run. So all you need to have is python insta
 On android you can use [termux](https://github.com/termux/termux-app).
 If you have any difficulty consult for help on the [discord channel](https://discord.gg/HBEmAwvbHV)
 
-### Installation on nixos
+### Installation on NixOS
 
 ![Static Badge](https://img.shields.io/badge/NixOs-black?style=flat&logo=nixos)
 
 ```bash
 nix profile install github:Benexl/fastanime
+```
+
+### Installation on Arch Linux
+
+> [!CAUTION]  
+> Avoid mixing installation methods. If you install FastAnime using the installation script, do not install it from the AUR. Similarly, if you use the AUR, avoid using the installation script. 
+> 
+> If you want to switch between methods, first uninstall the existing installation using the `--uninstall` command from the installation script, as explained below.  
+
+#### **Using the Installation Script**  
+
+To install FastAnime via the installation script, run: 
+
+```bash
+bash <(curl -L https://raw.githubusercontent.com/Benexl/FastAnime/refs/heads/master/install.sh) 
+```
+
+To uninstall FastAnime installed via the script, use:  
+
+```bash
+bash <(curl -L https://raw.githubusercontent.com/Benexl/FastAnime/refs/heads/master/install.sh) --uninstall
+```
+
+#### **Using the AUR Package**  
+
+FastAnime is available in the [AUR](https://aur.archlinux.org/) repository:  
+
+- [FastAnime](https://aur.archlinux.org/packages/fastanime) - Stable Build  
+- [FastAnime-Git](https://aur.archlinux.org/packages/fastanime-git) - Latest GitHub Build  
+
+You can install these packages using an AUR helper like `paru` or `yay`.  
+
+**With `paru`:** 
+
+```bash
+paru -S fastanime
+#or
+paru -S fastanime-git
+
+```
+**With `yay`:** 
+
+```bash 
+yay -S fastanime
+#or
+yay -S fastanime-git
 ```
 
 ### Installation using your favourite package manager

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,6 @@ install_gum() {
     fi
 }
 
-# Install paru
 install_paru() {
     echo "Installing paru..."
     sudo pacman -S --needed --noconfirm base-devel
@@ -63,7 +62,6 @@ install_paru() {
     rm -rf /tmp/paru
 }
 
-# Install yay
 install_yay() {
     echo "Installing yay..."
     sudo pacman -S --needed --noconfirm git base-devel

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -e  # Exit on any error
+
+if [[ $EUID -eq 0 ]]; then
+    echo "Please do not run this script as root. Dependencies will be installed with sudo where necessary."
+    exit 1
+fi
+
+# Define directories and resources
+REPO_URL="https://github.com/Benex254/FastAnime.git"
+BUILD_DIR="/tmp/fastanime-build"
+INSTALLED_RESOURCES=(
+    "/usr/share/licenses/fastanime/LICENSE"
+    "/usr/share/bash-completion/completions/fastanime"
+    "/usr/share/zsh/site-functions/_fastanime"
+    "/usr/share/fish/vendor_completions.d/fastanime.fish"
+)
+MISSING_DEPENDENCIES=(
+    "python-fastapi"
+    "python-inquirerpy"
+    "libtorrent"
+    "python-plyer"
+    "python-pytest"
+    "python-rich"
+    "python-thefuzz"
+    "python-pypresence"
+    "python-click"
+    "python-requests"
+    "yt-dlp"
+    "python-dbus"
+)
+OPTIONAL_DEPENDENCIES=(
+    "mpv"
+    "webtorrent-cli"
+    "ffmpeg"
+    "rofi"
+    "fzf"
+    "chafa"
+    "icat"
+    "ani-skip-git"
+    "ffmpegthumbnailer"
+    "syncplay"
+    "feh"
+)
+
+# Install gum if not present
+install_gum() {
+    if ! command -v gum >/dev/null 2>&1; then
+        echo "Installing gum..."
+        sudo pacman -S --needed --noconfirm gum
+    else
+        echo "gum is already installed."
+    fi
+}
+
+# Install paru
+install_paru() {
+    echo "Installing paru..."
+    sudo pacman -S --needed --noconfirm base-devel
+    git clone https://aur.archlinux.org/paru.git /tmp/paru
+    cd /tmp/paru || exit
+    makepkg -si --noconfirm
+    cd - || exit
+    rm -rf /tmp/paru
+}
+
+# Install yay
+install_yay() {
+    echo "Installing yay..."
+    sudo pacman -S --needed --noconfirm git base-devel
+    git clone https://aur.archlinux.org/yay.git /tmp/yay
+    cd /tmp/yay || exit
+    makepkg -si --noconfirm
+    cd - || exit
+    rm -rf /tmp/yay
+}
+
+# Install dependencies using the chosen AUR helper
+install_dependencies() {
+    local dependencies=("$@")
+    echo "Installing dependencies: ${dependencies[*]}"
+    for DEP in "${dependencies[@]}"; do
+        if ! pacman -Qi "$DEP" >/dev/null 2>&1; then
+            echo "Installing $DEP..."
+            $AUR_HELPER -S --noconfirm "$DEP"
+        else
+            echo "$DEP is already installed."
+        fi
+    done
+}
+
+# Uninstall function
+uninstall_fastanime() {
+    echo "Uninstalling FastAnime and its resources..."
+    for RESOURCE in "${INSTALLED_RESOURCES[@]}"; do
+        if [[ -f "$RESOURCE" ]]; then
+            sudo rm -f "$RESOURCE"
+            echo "Removed: $RESOURCE"
+        fi
+    done
+
+    echo "Removing Python package..."
+    sudo pip uninstall -y fastanime || echo "Python package not found."
+    echo "FastAnime has been successfully uninstalled!"
+}
+
+# Main install script
+main_install() {
+    install_gum
+
+    if command -v paru >/dev/null 2>&1; then
+        AUR_HELPER="paru"
+    elif command -v yay >/dev/null 2>&1; then
+        AUR_HELPER="yay"
+    else
+        echo "Neither paru nor yay is installed."
+        echo "By default, paru will be installed."
+        INSTALL_CHOICE=$(gum choose "Install paru (default)" "Install yay")
+        
+        if [[ "$INSTALL_CHOICE" == "Install yay" ]]; then
+            install_yay
+            AUR_HELPER="yay"
+        else
+            install_paru
+            AUR_HELPER="paru"
+        fi
+    fi
+
+    echo "Using AUR helper: $AUR_HELPER"
+
+    echo "Installing missing dependencies..."
+    install_dependencies "${MISSING_DEPENDENCIES[@]}"
+
+    echo
+    echo "Optional dependencies enhance functionality (e.g., mpv for playback, ffmpeg for streams)."
+    read -rp "Do you want to install optional dependencies? [y/N]: " INSTALL_OPTIONALS
+
+    if [[ "$INSTALL_OPTIONALS" =~ ^[Yy]$ ]]; then
+        install_dependencies "${OPTIONAL_DEPENDENCIES[@]}"
+    fi
+
+    echo "Cloning FastAnime repository..."
+    rm -rf "$BUILD_DIR"
+    git clone "$REPO_URL" "$BUILD_DIR"
+
+    echo "Building and installing FastAnime..."
+    cd "$BUILD_DIR" || exit
+    uv build
+    sudo python -m installer --destdir="/" dist/*.whl
+
+    echo "Installing additional resources..."
+    for RESOURCE in "${INSTALLED_RESOURCES[@]}"; do
+        sudo install -Dm644 "$(basename "$RESOURCE")" "$RESOURCE"
+    done
+
+    echo
+    echo "FastAnime has been installed successfully!"
+    echo "You can now run FastAnime from the terminal by typing: fastanime"
+}
+
+# Handle script arguments
+case "$1" in
+    --uninstall)
+        uninstall_fastanime
+        ;;
+    *)
+        main_install
+        ;;
+esac
+

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
-# Define directories and resources
 REPO_URL="https://github.com/Benex254/FastAnime.git"
 BUILD_DIR="/tmp/fastanime-build"
 INSTALLED_RESOURCES=(
@@ -44,7 +43,6 @@ OPTIONAL_DEPENDENCIES=(
     "feh"
 )
 
-# Install gum if not present
 install_gum() {
     if ! command -v gum >/dev/null 2>&1; then
         echo "Installing gum..."
@@ -76,7 +74,6 @@ install_yay() {
     rm -rf /tmp/yay
 }
 
-# Install dependencies using the chosen AUR helper
 install_dependencies() {
     local dependencies=("$@")
     echo "Installing dependencies: ${dependencies[*]}"
@@ -90,9 +87,10 @@ install_dependencies() {
     done
 }
 
-# Uninstall function
 uninstall_fastanime() {
     echo "Uninstalling FastAnime and its resources..."
+    
+    # remove fastanime directory ...
     for RESOURCE in "${INSTALLED_RESOURCES[@]}"; do
         if [[ -f "$RESOURCE" ]]; then
             sudo rm -f "$RESOURCE"
@@ -100,12 +98,18 @@ uninstall_fastanime() {
         fi
     done
 
-    echo "Removing Python package..."
-    sudo pip uninstall -y fastanime || echo "Python package not found."
+    if command -v fastanime >/dev/null 2>&1; then
+        FASTANIME_BIN=$(which fastanime)
+        sudo rm -f "$FASTANIME_BIN"
+        echo "Removed: $FASTANIME_BIN"
+    fi
+
+    # Conflict Dir With FastAnime Aur Package
+    sudo rm /usr/lib/python3.13/site-packages/fastanime -rf
+    sudo rm /usr/lib/python3.13/site-packages/fastanime-2.8.6.dist-info -rf
     echo "FastAnime has been successfully uninstalled!"
 }
 
-# Main install script
 main_install() {
     install_gum
 
@@ -159,7 +163,6 @@ main_install() {
     echo "You can now run FastAnime from the terminal by typing: fastanime"
 }
 
-# Handle script arguments
 case "$1" in
     --uninstall)
         uninstall_fastanime
@@ -168,4 +171,3 @@ case "$1" in
         main_install
         ;;
 esac
-


### PR DESCRIPTION
I know there is an AUR package for FastAnime in Arch Linux, but some necessary dependencies can't be installed because they are not available in pacman. This can cause the installation to fail, like it did on my system.  

To solve this, I made a one-click installation script for FastAnime on Arch Linux. It includes an `--uninstall` flag to remove all the files and directories installed by the script, helping avoid conflicts with the AUR package.  

I will also add a guide in the README to explain the installation clearly. This script is tested on my system and works well.
