### PR TITLE
refactor!: change notifier timeout config to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 
 </details>
 
-
 ## Installation
 
 ![Windows](https://img.shields.io/badge/-Windows_x64-blue.svg?style=for-the-badge&logo=windows)
@@ -209,7 +208,6 @@ The only required external dependency, unless you won't be streaming, is [MPV](h
 - [ffmpegthumbnailer](https://github.com/dirkvdb/ffmpegthumbnailer) used for local previews of downloaded anime
 - [syncplay](https://syncplay.pl/) to enable watch together.
 - [feh](https://github.com/derf/feh) used in manga mode
-
 
 ## Usage
 
@@ -773,7 +771,7 @@ rofi_theme_input =
 
 rofi_theme_confirm =
 
-notification_duration = 2
+notification_duration = 120
 
 sub_lang = eng
 
@@ -814,7 +812,6 @@ format = best[height<=1080]/bestvideo[height<=1080]+bestaudio/best
 player = mpv
 ```
 
-  
 ## Contributing
 
 pr's are highly welcome

--- a/fastanime/cli/commands/anilist/notifier.py
+++ b/fastanime/cli/commands/anilist/notifier.py
@@ -30,7 +30,7 @@ def notifier(config: "Config"):
 
     notified = os.path.join(APP_DATA_DIR, "last_notification.json")
     anime_image_path = os.path.join(APP_CACHE_DIR, "notification_image")
-    notification_duration = config.notification_duration * 60
+    notification_duration = config.notification_duration
     notification_image_path = ""
 
     if not config.user:

--- a/fastanime/cli/config.py
+++ b/fastanime/cli/config.py
@@ -57,7 +57,7 @@ class Config(object):
         "icons": "false",
         "image_previews": "True" if S_PLATFORM != "win32" else "False",
         "normalize_titles": "True",
-        "notification_duration": "2",
+        "notification_duration": "120",
         "max_cache_lifetime": "03:00:00",
         "per_page": "15",
         "player": "mpv",


### PR DESCRIPTION
This patch changes anilist notify timeout config from minutes to seconds. I feel normally, people prefer having notification to be in seconds and not minutes.
