### PR TITLE
fix: download in menu range fix

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -1059,16 +1059,16 @@ def download_anime(config: "Config", fastanime_runtime_state: "FastAnimeRuntimeS
             ep_range_tuple = episode_range.split(":")
             if len(ep_range_tuple) == 2 and all(ep_range_tuple):
                 episodes_start, episodes_end = ep_range_tuple
-                episodes_range = episodes[int(episodes_start) : int(episodes_end)]
+                episodes_range = episodes[int(episodes_start) - 1: int(episodes_end)]
             elif len(ep_range_tuple) == 3 and all(ep_range_tuple):
                 episodes_start, episodes_end, step = ep_range_tuple
                 episodes_range = episodes[
-                    int(episodes_start) : int(episodes_end) : int(step)
+                    int(episodes_start) - 1: int(episodes_end) : int(step)
                 ]
             else:
                 episodes_start, episodes_end = ep_range_tuple
                 if episodes_start.strip():
-                    episodes_range = episodes[int(episodes_start) :]
+                    episodes_range = episodes[int(episodes_start) - 1 :]
                 elif episodes_end.strip():
                     episodes_range = episodes[: int(episodes_end)]
                 else:


### PR DESCRIPTION
When using the download in menu feature introduced by 98e41e1,
downloading using range (3:5) doesn't work as expected. It starts
incremented by 1. Example: 3:5 selects episodes 4 and 5.

This patch addresses this issue by simply decrementing the start_episode
variable by 1 before adding adding to range list.
