### PR TITLE
refactor: just move next episode to the top

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -329,8 +329,8 @@ def media_player_controls(
 
     icons = config.icons
     options = {
-        f"{'🔂 ' if icons else ''}Replay": _replay,
         f"{'⏭  ' if icons else ''}Next Episode": _next_episode,
+        f"{'🔂 ' if icons else ''}Replay": _replay,
         f"{'⏮  ' if icons else ''}Previous Episode": _previous_episode,
         f"{'🗃️ ' if icons else ''}Episodes": _episodes,
         f"{'📀 ' if icons else ''}Change Quality": _change_quality,


### PR DESCRIPTION
When watching episodes, it makes sense to go to the next episode after
completing the current one. Currently, when an episode is completed,
replay button appears first in media_player_controls menu.

This patch just moves replay button below such that the next episode
button takes priority, and the user can watch the next episode with a
single key press (\<return\>) which is less immersion breaking than
(\<down\> \<return\>).
