### PR TITLE
fix: fixed off by one error in condition of continuing anime from Wat…

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -756,6 +756,7 @@ def provider_anime_episodes_menu(
                     "progress"
                 )
             )
+            current_episode_number = str(int(current_episode_number) + 1)
             if current_episode_number not in available_episodes:
                 current_episode_number = ""
             print(


### PR DESCRIPTION
fixed off by one error when these conditions are met:
- logged into anilist
- select anime from watching that that is not in watch_history.json
- stream selected anime

This issue exists because watch_history.json stores ep numbers of "last episode watched" + 1  but getting the episode number from anilist returns the last episode watched.