### PR TITLE
fix: config preferred_history option was unused

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -706,12 +706,13 @@ def provider_anime_episodes_menu(
         # the user watch history thats locally available
         # will be preferred over remote
         if (
-            user_watch_history.get(str(anime_id_anilist), {}).get("episode_no")
-            in available_episodes
+            config.preferred_history == "local"
+            or not selected_anime_anilist["mediaListEntry"]
         ):
             if (
-                config.preferred_history == "local"
-                or not selected_anime_anilist["mediaListEntry"]
+
+                user_watch_history.get(str(anime_id_anilist), {}).get("episode_no")
+                in available_episodes
             ):
                 current_episode_number = user_watch_history[str(anime_id_anilist)][
                     "episode_no"


### PR DESCRIPTION
config option "preferred_history" was unused due to a if check for if the animeid existed in watch_history.json that bypassed the check for preferred_history.

This was an issue because the option to use remote history was an elif.