### PR TITLE
feat: hide next episode button on reaching last episode

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -329,8 +329,14 @@ def media_player_controls(
         media_player_controls(config, fastanime_runtime_state)
 
     icons = config.icons
-    options = {
-        f"{'⏭  ' if icons else ''}Next Episode": _next_episode,
+    options = {}
+
+    # Only show Next Episode option if the current episode is not the last one
+    current_index = available_episodes.index(current_episode_number)
+    if current_index < len(available_episodes) - 1:
+        options[f"{'⏭  ' if icons else ''}Next Episode"] = _next_episode
+
+    options.update({
         f"{'🔂 ' if icons else ''}Replay": _replay,
         f"{'⏮  ' if icons else ''}Previous Episode": _previous_episode,
         f"{'🗃️ ' if icons else ''}Episodes": _episodes,
@@ -347,12 +353,15 @@ def media_player_controls(
             config, fastanime_runtime_state
         ),
         f"{'❌ ' if icons else ''}Exit": exit_app,
-    }
+    })
 
     if config.auto_next:
-        print("Auto selecting next episode")
-        _next_episode()
-        return
+        if current_index < len(available_episodes) - 1:
+            print("Auto selecting next episode")
+            _next_episode()
+            return
+        else:
+            print("Last episode reached")
 
     choices = list(options.keys())
     if config.use_fzf:


### PR DESCRIPTION
Hides the next episode button if the currently completed episode is the
last available episode on the server. Also affects auto-next feature,
where it returns to media actions menu on completion of last episode.

To note: Used Claude 3.7 sonnet (Github Copilot) for assistance, so verify before merging. Of course, I have tested it with and without auto-next config.
