### PR TITLE
fix: fixed relations menu and only show ANIME

### DIFF
--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -1632,7 +1632,8 @@ def media_actions_menu(
             media_actions_menu(config, fastanime_runtime_state)
             return
 
-        relations = relations[1]["data"]["Page"]["relations"]  # pyright:ignore
+        relations = relations[1]["data"]["Media"]["relations"]  # pyright:ignore
+        relations["nodes"] = [node for node in relations["nodes"] if node.get("type") == "ANIME"]
         fastanime_runtime_state.anilist_results_data = {
             "data": {"Page": {"media": relations["nodes"]}}  # pyright:ignore
         }

--- a/fastanime/libs/anilist/queries_graphql.py
+++ b/fastanime/libs/anilist/queries_graphql.py
@@ -846,6 +846,7 @@ query ($id: Int) {
       nodes {
         id
         idMal
+        type
         title {
           english
           romaji


### PR DESCRIPTION
fixed the relations menu in an anime entry not working and also changed it so it only shows relations of type "ANIME" wich include OVA's and Movies but exclude Manga or Novel since clicking on those went to the anime or crashed

let me know if i should change or improve anything