### PR TITLE
Add a --no-check-certificate flag

### DIFF
--- a/fastanime/Utility/downloader/downloader.py
+++ b/fastanime/Utility/downloader/downloader.py
@@ -46,6 +46,7 @@ class YtDLPDownloader:
         force_ffmpeg=False,
         hls_use_mpegts=False,
         hls_use_h264=False,
+        nocheckcertificate=False,
     ):
         """Helper function that downloads anime given url and path details
 
@@ -87,6 +88,7 @@ class YtDLPDownloader:
             "format": vid_format,
             "compat_opts": ("allow-unsafe-ext",) if force_unknown_ext else tuple(),
             "progress_hooks": progress_hooks,
+            "nocheckcertificate": nocheckcertificate,
         }
         urls = [url]
         if sub:

--- a/fastanime/cli/commands/anilist/download.py
+++ b/fastanime/cli/commands/anilist/download.py
@@ -124,6 +124,11 @@ from .data import (
     help="Use H.264 (MP4) for hls streams, resulted in .mp4 file (useful for some streams: see Docs) (this option forces --force-ffmpeg to be True)",
 )
 @click.option(
+    "--no-check-certificates",
+    is_flag=True,
+    help="Suppress HTTPS certificate validation",
+)
+@click.option(
     "--max-results", "-M", type=int, help="The maximum number of results to show"
 )
 @click.pass_obj
@@ -149,6 +154,7 @@ def download(
     force_ffmpeg,
     hls_use_mpegts,
     hls_use_h264,
+    no_check_certificates,
     max_results,
 ):
     from rich import print
@@ -386,6 +392,7 @@ def download(
                         force_ffmpeg=force_ffmpeg,
                         hls_use_mpegts=hls_use_mpegts,
                         hls_use_h264=hls_use_h264,
+                        nocheckcertificate=no_check_certificates,
                     )
                 except Exception as e:
                     print(e)

--- a/fastanime/cli/commands/download.py
+++ b/fastanime/cli/commands/download.py
@@ -129,6 +129,11 @@ if TYPE_CHECKING:
     is_flag=True,
     help="Use H.264 (MP4) for hls streams, resulted in .mp4 file (useful for some streams: see Docs) (this option forces --force-ffmpeg to be True)",
 )
+@click.option(
+    "--no-check-certificates",
+    is_flag=True,
+    help="Suppress HTTPS certificate validation",
+)
 @click.pass_obj
 def download(
     config: "Config",
@@ -145,6 +150,7 @@ def download(
     force_ffmpeg,
     hls_use_mpegts,
     hls_use_h264,
+    no_check_certificates,
 ):
     import time
 
@@ -208,6 +214,7 @@ def download(
                 force_ffmpeg,
                 hls_use_mpegts,
                 hls_use_h264,
+                no_check_certificates,
             )
             return
         search_results = search_results["results"]
@@ -262,6 +269,7 @@ def download(
                 force_ffmpeg,
                 hls_use_mpegts,
                 hls_use_h264,
+                no_check_certificates,
             )
             return
 
@@ -399,6 +407,7 @@ def download(
                     force_ffmpeg=force_ffmpeg,
                     hls_use_mpegts=hls_use_mpegts,
                     hls_use_h264=hls_use_h264,
+                    nocheckcertificate=no_check_certificates,
                 )
             except Exception as e:
                 print(e)

--- a/fastanime/cli/interfaces/anilist_interfaces.py
+++ b/fastanime/cli/interfaces/anilist_interfaces.py
@@ -1022,6 +1022,7 @@ def download_anime(config: "Config", fastanime_runtime_state: "FastAnimeRuntimeS
     force_ffmpeg = Confirm.ask("Force ffmpeg", default=False)
     hls_use_mpegts = Confirm.ask("Use mpegts", default=False)
     hls_use_h264 = Confirm.ask("Use h264", default=False)
+    nocheckcertificate = True
 
     force_ffmpeg |= hls_use_mpegts or hls_use_h264
     anime_title = Prompt.ask(
@@ -1218,6 +1219,7 @@ def download_anime(config: "Config", fastanime_runtime_state: "FastAnimeRuntimeS
                 force_ffmpeg=force_ffmpeg,
                 hls_use_mpegts=hls_use_mpegts,
                 hls_use_h264=hls_use_h264,
+                nocheckcertificate=nocheckcertificate,
             )
         except Exception as e:
             print(e)

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         pname = "fastanime";
         version = "2.8.8";
 
-        src = ./.;
+        src = self;
 
         preBuild = ''
           sed -i 's/rich>=13.9.2/rich>=13.8.1/' pyproject.toml

--- a/flake.nix
+++ b/flake.nix
@@ -50,14 +50,20 @@
 
       # DevShell for development
       devShells.default = pkgs.mkShell {
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.libxcrypt-legacy ];
         buildInputs = [
           fastanimeEnv
           pythonPackages.hatchling
           pkgs.mpv
-          pkgs.libmpv
           pkgs.fzf
           pkgs.rofi
+          pkgs.uv
+          pkgs.pyright
         ];
+        shellHook = ''
+          uv venv -q
+          source ./.venv/bin/activate
+        '';
       };
     });
 }


### PR DESCRIPTION
I added a --no-check-certificates flag as a workaround to yt-dlp erroring out with the error message below.
Feel free to use or close this PR, I don't mind either way.

```
ERROR: [generic] Unable to download webpage: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010) (caused by CertificateVerifyError('[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)')); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
[0;31mERROR:[0m [generic] Unable to download webpage: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1010) (caused by CertificateVerifyError('[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)'));
please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue
template. Confirm you are on the latest version using  yt-dlp -U
```

Note: An actual fix probably involves adding the certifi package, according to various yt-dlp issues such as https://github.com/yt-dlp/yt-dlp/issues/10485