### PR TITLE
Use int() cast instead of is_integer() for renumbered_val

### DIFF
--- a/fastanime/core/utils/formatter.py
+++ b/fastanime/core/utils/formatter.py
@@ -244,7 +244,7 @@ def renumber_titles(titles: List[str]) -> Dict[str, Union[int, float, None]]:
             renumbered_val = round(base_val + offset, 3)
 
         renumbered[title] = (
-            int(renumbered_val) if renumbered_val.is_integer() else renumbered_val
+            int(renumbered_val) if int(renumbered_val) else renumbered_val
         )
 
     # Add back the unnumbered titles with `None`

--- a/fastanime/core/utils/formatter.py
+++ b/fastanime/core/utils/formatter.py
@@ -243,9 +243,7 @@ def renumber_titles(titles: List[str]) -> Dict[str, Union[int, float, None]]:
             offset = round(orig_ep - int_part, 3)
             renumbered_val = round(base_val + offset, 3)
 
-        renumbered[title] = (
-            int(renumbered_val) if int(renumbered_val) else renumbered_val
-        )
+        renumbered[title] = renumbered_val
 
     # Add back the unnumbered titles with `None`
     for t in without_numbers:


### PR DESCRIPTION
This was causing an AttributeError given that renumbered_val was an integer and the is_integer() method is meant to be used on float instead.